### PR TITLE
Add config opt to skip registration for the given machine

### DIFF
--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
           guest = @env[:machine].guest
           @logger.info("Testing for registration_register capability on ")
 
-          if guest.capability?(:register)
+          if guest.capability?(:register) && !@env[:machine].config.registration.skip
             env[:ui].info("Registering box with vagrant-registration...")
             @logger.info("registration_register capability exists on ")
             result = guest.capability(:register)

--- a/lib/vagrant-registration/action/unregister.rb
+++ b/lib/vagrant-registration/action/unregister.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
         def call(env)
           guest = @env[:machine].guest
           #   @logger.info("Testing for registration_unregister capability on ")
-          if guest.capability?(:unregister)
+          if guest.capability?(:unregister) && !@env[:machine].config.registration.skip
             env[:ui].info("Unregistering box with vagrant-registration...")
             @logger.info("registration_unregister capability exists on ")
             result = guest.capability(:unregister)

--- a/lib/vagrant-registration/config.rb
+++ b/lib/vagrant-registration/config.rb
@@ -13,14 +13,21 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :subscriber_password
 
+      # Skip the registration (skip if true)
+      #
+      # @return [Bool]
+      attr_accessor :skip
+
       def initialize(region_specific=false)
         @subscriber_username = UNSET_VALUE
         @subscriber_password = UNSET_VALUE
+        @skip = UNSET_VALUE
       end
 
       def finalize!
         @subscriber_username = nil if @subscriber_username == UNSET_VALUE
         @subscriber_password = nil if @subscriber_password == UNSET_VALUE
+        @skip = false if @skip == UNSET_VALUE
       end
     end
   end


### PR DESCRIPTION
Sometimes can be handy to avoid the registration for a given machine (e.g. some testing). This PR adds the `skip` option.

```
# Excerp from Vagrantfile
  config.vm.box = "rhel7"
  config.registration.skip = true
```